### PR TITLE
Time Series Data Labeling Tool - Keeping labeling mode active

### DIFF
--- a/ui/src/app/core-ui/linechart/lineChart.component.html
+++ b/ui/src/app/core-ui/linechart/lineChart.component.html
@@ -36,7 +36,7 @@
                      [data]="dataToDisplay"
                      [layout]="graph.layout"
                      [config]="graph.config"
-                     (relayout)="zoomIn($event)"
+                     (relayout)="handleDefaultModeBarButtonClicks($event)"
                      (selecting)="selectDataPoints($event)">
         </plotly-plot>
 


### PR DESCRIPTION
Hi there,
I have extended the time series data labeling tool in such a way that the labeling mode now remains activated after clicking the 'Labeling'-button - until it gets deactivated by clicking the button again or by switching to the plotly-specific 'Pan' or 'Zoom' mode.

The activation of the labeling mode is highlighted by color adjustment of the 'Labeling'-button icon (see also: attached screenshot).

![sp-data-labeling-mode-active](https://user-images.githubusercontent.com/33521958/78188413-78332b80-7470-11ea-8fc1-c2cfadad8f44.png)