### PR TITLE
[STREAMPIPES-106] Upgrade Siddhi dependency to v5.1.12

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -297,6 +297,10 @@ io.dropwizard.metrics:metrics-json:3.1.5
 io.dropwizard.metrics:metrics-jvm:3.1.5
 io.netty:netty-all:4.1.17.Final
 io.netty:netty:3.9.9.Final
+io.siddhi:siddhi-annotations:5.1.12
+io.siddhi:siddhi-core:5.1.12
+io.siddhi:siddhi-query-api:5.1.12
+io.siddhi:siddhi-query-compiler:5.1.12
 io.undertow:undertow-core:2.0.27.Final
 io.undertow:undertow-servlet:2.0.27.Final
 io.undertow:undertow-websockets-jsr:2.0.27.Final
@@ -505,10 +509,6 @@ org.streampipes:streampipes-empire-cp-common-utils:1.9.11
 org.streampipes:streampipes-empire-cp-openrdf-utils:1.9.11
 org.streampipes:streampipes-empire-pinto:1.9.11
 org.streampipes:streampipes-empire-rdf4j:1.9.11
-org.wso2.siddhi:siddhi-annotations:4.5.11
-org.wso2.siddhi:siddhi-core:4.5.11
-org.wso2.siddhi:siddhi-query-api:4.5.11
-org.wso2.siddhi:siddhi-query-compiler:4.5.11
 org.xerial.snappy:snappy-java:1.1.7.2
 org.xmlunit:xmlunit-core:2.6.2
 org.xmlunit:xmlunit-placeholders:2.6.2

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <rendersnake.version>1.8</rendersnake.version>
         <retrofit.version>2.5.0</retrofit.version>
         <shiro.version>1.2.3</shiro.version>
-        <siddhi.version>4.5.11</siddhi.version>
+        <siddhi.version>5.1.12</siddhi.version>
         <slf4j.version>1.7.25</slf4j.version>
         <snappy-java.version>1.1.7.2</snappy-java.version>
         <spark.version>2.1.2</spark.version>
@@ -711,22 +711,22 @@
                 <version>${cloning.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.siddhi</groupId>
+                <groupId>io.siddhi</groupId>
                 <artifactId>siddhi-annotations</artifactId>
                 <version>${siddhi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.siddhi</groupId>
+                <groupId>io.siddhi</groupId>
                 <artifactId>siddhi-core</artifactId>
                 <version>${siddhi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.siddhi</groupId>
+                <groupId>io.siddhi</groupId>
                 <artifactId>siddhi-query-api</artifactId>
                 <version>${siddhi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.siddhi</groupId>
+                <groupId>io.siddhi</groupId>
                 <artifactId>siddhi-query-compiler</artifactId>
                 <version>${siddhi.version}</version>
             </dependency>

--- a/streampipes-wrapper-siddhi/pom.xml
+++ b/streampipes-wrapper-siddhi/pom.xml
@@ -17,7 +17,8 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>streampipes-parent</artifactId>
         <groupId>org.apache.streampipes</groupId>
@@ -37,19 +38,19 @@
 
         <!-- External dependencies -->
         <dependency>
-            <groupId>org.wso2.siddhi</groupId>
+            <groupId>io.siddhi</groupId>
             <artifactId>siddhi-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.siddhi</groupId>
+            <groupId>io.siddhi</groupId>
             <artifactId>siddhi-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.siddhi</groupId>
+            <groupId>io.siddhi</groupId>
             <artifactId>siddhi-query-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.siddhi</groupId>
+            <groupId>io.siddhi</groupId>
             <artifactId>siddhi-query-compiler</artifactId>
         </dependency>
     </dependencies>

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiDebugCallback.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiDebugCallback.java
@@ -18,7 +18,7 @@
 package org.apache.streampipes.wrapper.siddhi.engine;
 
 
-import org.wso2.siddhi.core.event.Event;
+import io.siddhi.core.event.Event;
 
 public interface SiddhiDebugCallback {
 

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -28,11 +28,11 @@ import org.apache.streampipes.wrapper.params.binding.EventProcessorBindingParams
 import org.apache.streampipes.wrapper.routing.SpOutputCollector;
 import org.apache.streampipes.wrapper.runtime.EventProcessor;
 import org.apache.streampipes.wrapper.siddhi.manager.SpSiddhiManager;
-import org.wso2.siddhi.core.SiddhiAppRuntime;
-import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.stream.output.StreamCallback;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.stream.output.StreamCallback;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/manager/SpSiddhiManager.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/manager/SpSiddhiManager.java
@@ -17,7 +17,7 @@
  */
 package org.apache.streampipes.wrapper.siddhi.manager;
 
-import org.wso2.siddhi.core.SiddhiManager;
+import io.siddhi.core.SiddhiManager;
 
 public enum SpSiddhiManager {
 


### PR DESCRIPTION
Hi there,

This PR will upgrade Siddhi dependency to v5.1.12. There are no breaking changes to the from 4.x to 5.x. However, the org names have changed from `org.wso2` to `io.siddhi`, and there's lot of other improvements.

Fixes: https://issues.apache.org/jira/projects/STREAMPIPES/issues/STREAMPIPES-106

Regards,
Grainier