### PR TITLE
[STREAMPIPES-108] Integrate CVE maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.locations.enabled>false</dependency.locations.enabled>
+        <owasp.check.skip>false</owasp.check.skip>
 
         <activemq-client.version>5.15.9</activemq-client.version>
         <asm.version>7.0</asm.version>
@@ -110,6 +111,7 @@
         <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <maven.jar.plugin.version>3.1.2</maven.jar.plugin.version>
         <maven.source.plugin.version>3.1.0</maven.source.plugin.version>
+        <maven.dependency.check.plugin.version>5.2.2</maven.dependency.check.plugin.version>
     </properties>
 
     <name>Apache StreamPipes</name>
@@ -1153,6 +1155,29 @@
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${maven.dependency.check.plugin.version}</version>
+                <configuration>
+                    <!-- use -Dowasp.check.skip=true to skip dependency check -->
+                    <skip>${owasp.check.skip}</skip>
+                    <format>HTML</format>
+                    <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                    <failOnError>false</failOnError>
+                    <suppressionFile>tools/maven/owasp-dependency-check-suppression.xml</suppressionFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <!-- generates aggregated reports in target/ -->
+                            <goal>check</goal>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tools/maven/owasp-dependency-check-suppression.xml
+++ b/tools/maven/owasp-dependency-check-suppression.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+    <!--
+        refer : https://jeremylong.github.io/DependencyCheck/general/suppression.html
+        for samples on suppressing false positives.
+    -->
+    <suppress>
+        <notes><![CDATA[
+        This suppresses all CVE entries that have a score below CVSS 7.
+        ]]></notes>
+        <cvssBelow>7</cvssBelow>
+    </suppress>
+
+</suppressions>


### PR DESCRIPTION
## Purpose
Purpose of this pull request is to integrate the CVE maven plugin for StreamPipes to check security vulnerabilities found in dependencies during build time. This will help to detect publicly disclosed vulnerabilities contained within StreamPipes dependencies (and the dependencies of all child modules).

## Usage
This plugin configuration is attached to the `mvn verify` phase. Therefore, this will run automatically when we perform a `mvn clean verify`. Once the `mvn` process is completed, the plugin will create a `dependency-check-report.html` report in `target/` dir with the detect vulnerabilities.

In case if you need to skip this plugin, use `owasp.check.skip=true` property (i.e `mvn clean verify -Dowasp.check.skip=true`).

## Remarks
- Fixes https://issues.apache.org/jira/browse/STREAMPIPES-108
- https://github.com/jeremylong/DependencyCheck
- https://jeremylong.github.io/DependencyCheck/general/suppression.html