### PR TITLE
[WIP] Clear sortedEventKeys before adding new keys

### DIFF
--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -164,6 +164,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
     String defineStreamPrefix = "define stream " + prepareName(eventTypeName);
     StringJoiner joiner = new StringJoiner(",");
 
+    sortedEventKeys.clear();
     for (String key : typeMap.keySet()) {
       sortedEventKeys.add(key);
       Collections.sort(sortedEventKeys);


### PR DESCRIPTION
### Purpose
Fixes an issue that appears when more than one stream is connected to a Siddhi processing element.
Before, when the second stream is added to Siddhi by creating the "define stream..." string, keys from the first stream remained in the `sortedEventKeys` ArrayList.
This resulted in a `NullPointerException` because these keys could not be found in the `typeMap` HashMap.

### Approach
Clear `sortedEventKeys` before adding new keys by calling the `ArrayList.clear()` method.
