### PR TITLE
Add list of event keys to allow for Siddhi PEs with multiple streams

### DIFF
--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -294,9 +294,12 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
     return selectString.toString();
   }
 
-  /*
   public void setSortedEventKeys(List<String> sortedEventKeys) {
-    this.sortedEventKeys = sortedEventKeys;
+    String streamId = (String) this.listOfEventKeys.keySet().toArray()[0];    // only reliable if there is only one stream, else use changeEventKeys() to respective streamId
+    changeEventKeys(streamId, sortedEventKeys);
   }
-   */
+
+  public void changeEventKeys(String streamId, List<String> newEventKeys) {
+    this.listOfEventKeys.put(streamId, newEventKeys);
+  }
 }

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -170,7 +170,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
       Collections.sort(sortedEventKeys);
     }
 
-    listOfEventKeys.put(eventTypeName, sortedEventKeys)
+    listOfEventKeys.put(eventTypeName, sortedEventKeys);
 
     for (String key : sortedEventKeys) {
       // TODO: get timestamp field from user params
@@ -220,7 +220,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
   @Override
   public void onEvent(org.apache.streampipes.model.runtime.Event event, SpOutputCollector collector) {
     try {
-      String sourceId = event.getSourceInfo().getSourceId()
+      String sourceId = event.getSourceInfo().getSourceId();
       InputHandler inputHandler = siddhiInputHandlers.get(sourceId);
       List<String> eventKeys = listOfEventKeys.get(sourceId);
 
@@ -294,7 +294,9 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
     return selectString.toString();
   }
 
+  /*
   public void setSortedEventKeys(List<String> sortedEventKeys) {
     this.sortedEventKeys = sortedEventKeys;
   }
+   */
 }

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -170,7 +170,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
       Collections.sort(sortedEventKeys);
     }
 
-    listOfEventKeys.put(prepareName(eventTypeName), sortedEventKeys)
+    listOfEventKeys.put(eventTypeName, sortedEventKeys)
 
     for (String key : sortedEventKeys) {
       // TODO: get timestamp field from user params
@@ -222,7 +222,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
     try {
       String sourceId = event.getSourceInfo().getSourceId()
       InputHandler inputHandler = siddhiInputHandlers.get(sourceId);
-      List<String> eventKeys = listOfEventKeys.get(prepareName(sourceId));
+      List<String> eventKeys = listOfEventKeys.get(sourceId);
 
       inputHandler.send(toObjArr(eventKeys, event.getRaw()));
     } catch (InterruptedException e) {

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -163,6 +163,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
   private void registerEventTypeIfNotExists(String eventTypeName, Map<String, Object> typeMap) {
     String defineStreamPrefix = "define stream " + prepareName(eventTypeName);
     StringJoiner joiner = new StringJoiner(",");
+    int currentNoOfStreams = this.listOfEventKeys.size();
 
     List<String> sortedEventKeys = new ArrayList<>();
     for (String key : typeMap.keySet()) {
@@ -175,10 +176,10 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
     for (String key : sortedEventKeys) {
       // TODO: get timestamp field from user params
       if(key.equalsIgnoreCase(this.timestampField)) {
-        joiner.add("s0" + key + " LONG");
+        joiner.add("s" + currentNoOfStreams + key + " LONG");
       }
       else {
-        joiner.add("s0" + key + " " + toType((Class<?>) typeMap.get(key)));
+        joiner.add("s" + currentNoOfStreams + key + " " + toType((Class<?>) typeMap.get(key)));
       }
     }
 


### PR DESCRIPTION
### Purpose
1. Currently, there is only one list of event keys (attributes), which gets expanded with the keys from all streams: `sortedEventKeys`. When connecting multiple streams to a Siddhi processing element, this leads to a `NullPointerException` and duplicate keys in the stream definition clause. This PR adds a HashMap containing a separate list of event keys for each stream.
2. If both connected streams had the same attribute name, a Siddhi exception was raised. This PR changes attribute naming to that the second stream is prefixed "s1", the third "s2", etc. So if using the integrated Flow Rate 1 and Flow Rate 2 adapters, this would mean the mass_flow attribute is called `s0mass_flow` for the first and `s1mass_flow` for the second stream.

### Approach
1. Adds the `listOfEventKeys` HashMap. Keys are the stream names, values are the lists containing the respective event key. This is somewhat similar to the already existing `siddhiInputHandlers` Map, just with a different purpose.
2. Changes `registerEventTypeIfNotExists()` to put new event keys there when invocating the processing element.
3. Changes `onEvent()` and `toObjArr()` to use the HashMap when receiving new events.
4. Change attribute naming in `registerEventTypeIfNotExists()` by counting the number of elements in `listOfEventKeys` and prefixing accordingly.

### Remarks
Jira issue: None
