### PR TITLE
Fixes for multiple stream attribute naming

### DIFF
--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -295,6 +295,26 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
     return selectString.toString();
   }
 
+  protected String getCustomOutputSelectStatement(DataProcessorInvocation invocation, int streamNumber) {
+    return getCustomOutputSelectStatement(invocation, null, streamNumber);
+  }
+  protected String getCustomOutputSelectStatement(DataProcessorInvocation invocation,
+                                                  String eventName,
+                                                  int streamNumber) {
+    StringBuilder selectString = new StringBuilder();
+    selectString.append("select ");
+    String prefix = (eventName == null) ? "s" + streamNumber : eventName + ".s" + streamNumber;
+
+    if (outputEventKeys.size() > 0) {
+      for (int i = 0; i < outputEventKeys.size() - 1; i++) {
+        selectString.append(prefix + outputEventKeys.get(i) + ",");
+      }
+      selectString.append(prefix + outputEventKeys.get(outputEventKeys.size() - 1));
+
+    }
+    return selectString.toString();
+  }
+
   public void setSortedEventKeys(List<String> sortedEventKeys) {
     String streamId = (String) this.listOfEventKeys.keySet().toArray()[0];    // only reliable if there is only one stream, else use changeEventKeys() to respective streamId
     changeEventKeys(streamId, sortedEventKeys);

--- a/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
+++ b/streampipes-wrapper-siddhi/src/main/java/org/apache/streampipes/wrapper/siddhi/engine/SiddhiEventEngine.java
@@ -129,7 +129,7 @@ public abstract class SiddhiEventEngine<B extends EventProcessorBindingParams> i
   }
 
   private String removeStreamIdFromTimestamp(String timestampField) {
-    return timestampField !=null ? timestampField.replaceAll("s0::", "") : null;
+    return timestampField !=null ? timestampField.replaceAll("s.::", "") : null;
   }
 
   private String getOutputTopicName(B parameters) {


### PR DESCRIPTION
### Purpose
Following up on #22, concretely the change of attribute naming.
1. In `removeStreamIdFromTimestamp()`, a prefix of "s0" was assumed, when the timestamp could also be from another stream.
2. `getCustomOutputSelectStatement()` also assumes "s0" as prefix.

### Approach
For 1: Change the regex to use a wildcard character (`.`).
For 2: Overload `getCustomOutputSelectStatement()` with the possibility to specify a stream number to be used.

### Remarks
Jira issue: None
