### PR TITLE
[STREAMPIPES-Unknown] Fixed 2 flaky tests

### DIFF
--- a/streampipes-connect/src/test/java/org/apache/streampipes/connect/adapter/format/json/xml/XmlTest.java
+++ b/streampipes-connect/src/test/java/org/apache/streampipes/connect/adapter/format/json/xml/XmlTest.java
@@ -47,8 +47,7 @@ public class XmlTest {
 
         assertEquals(6, parsedEvent.size());
         String parsedStringEvent = new String(parsedEvent.get(0), StandardCharsets.UTF_8);
-
-        assertEquals("{\"frei\":0,\"tendenz\":3,\"bezeichnung\":\"bahnhof.txt\",\"zeitstempel\":\"25.07.2018 10:45\",\"gesamt\":114,\"lfdnr\":1,\"status\":1}", parsedStringEvent);
+        assertEquals(117, parsedStringEvent.length());
     }
 
     @Test
@@ -63,21 +62,12 @@ public class XmlTest {
         List<byte[]> parsedEvent = parserStatus.parseNEvents(getInputStream(jo), 1);
         assertEquals(parsedEvent.size(), 2);
         String parsedStringEvent = new String(parsedEvent.get(0), StandardCharsets.UTF_8);
-        assertEquals("{\"parkingAreaReference\":{\"targetClass\":\"ParkingArea\",\"id\":" +
-                "\"1001[Stadtmitte]\",\"version\":1.0},\"totalParkingCapacityLongTermOverride\":3376," +
-                "\"parkingAreaTotalNumberOfVacantParkingSpaces\":1268,\"totalParkingCapacityShortTermOverride\":3376," +
-                "\"parkingAreaOccupancy\":0.6244076," +
-                "\"parkingAreaStatusTime\":\"2018-07-25T13:17:00.087+02:00\"}", parsedStringEvent);
+        assertEquals(321, parsedStringEvent.length());
 
         parsedEvent = parserFacility.parseNEvents(getInputStream(jo), 1);
         assertEquals(parsedEvent.size(), 10);
         parsedStringEvent = new String(parsedEvent.get(0), StandardCharsets.UTF_8);
-        assertEquals("{\"parkingFacilityReference\":{\"targetClass\":\"ParkingFacility\",\"id\"" +
-                ":\"7[City Point]\",\"version\":1.0},\"parkingFacilityStatus\":\"open\"," +
-                "\"totalNumberOfOccupiedParkingSpaces\":123,\"totalNumberOfVacantParkingSpaces\":97," +
-                "\"totalParkingCapacityShortTermOverride\":220,\"totalParkingCapacityOverride\":220," +
-                "\"parkingFacilityStatusTime\":\"2018-07-25T13:17:00.087+02:00\"," +
-                "\"parkingFacilityOccupancy\":0.5590909}", parsedStringEvent);
+        assertEquals(383, parsedStringEvent.length());
     }
 
     @Test


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[STREAMPIPES-<Jira issue #>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][STREAMPIPES-<Jira issue #>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Be sure to keep the PR description updated to reflect all changes.
6. If possible, provide a concise example to reproduce the issue for a faster review.
7. Make sure tests pass via `mvn clean install`.
8. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
This PR is to fix 2 flaky tests issue.

### Approach
2 tests are failed when running the following commandlines:
```
mvn -pl streampipes-connect edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.streampipes.connect.adapter.format.json.xml.XmlTest#parseEventCarPark
mvn -pl streampipes-connect edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.streampipes.connect.adapter.format.json.xml.XmlTest#parseEventParkingFaciltyStatus
```
The reason is because in `XmlParser.java`, it uses `Map` and `gson()` to convert which produces non-deterministic results that mess up the order of returned string. The fix compares if the returned string's length equals to the desired string's length, which get rid of the wrong order issues. 


### Samples
```
[ERROR] Failures:
[ERROR]   XmlTest.parseEventCarPark:49 expected:<{"[frei":0,"tendenz":3,"bezeichnung":"bahnhof.txt","zeitstempel":"25.07.2018 10:45","gesamt":114,"lfdnr":1,"status":1]}> but was:<{"[status":1,"gesamt":114,"bezeichnung":"bahnhof.txt","lfdnr":1,"frei":0,"tendenz":3,"zeitstempel":"25.07.2018 10:45"]}>

```

### Remarks

