### PR TITLE
[STREAMPIPES-479] Add spring-context-support dependency

### DIFF
--- a/streampipes-container-base/pom.xml
+++ b/streampipes-container-base/pom.xml
@@ -71,6 +71,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-undertow</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
 
         <!--dependency convergence-->
         <dependency>


### PR DESCRIPTION
Add 
        <dependency>
            <groupId>org.springframework</groupId>
            <artifactId>spring-context-support</artifactId>
        </dependency>

to  streampipes-container-base