### PR TITLE
[STREAMPIPES-506] Fix wrong default time zones in data-explorer widgets

### DIFF
--- a/ui/src/app/data-explorer/components/widgets/correlation-chart/correlation-chart-widget.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/correlation-chart/correlation-chart-widget.component.ts
@@ -164,7 +164,7 @@ export class CorrelationChartWidgetComponent extends BaseDataExplorerWidget<Corr
           //   row: rowCount,
           //   column: colCount,
           // },
-        };
+        };    
 
         this.data.push(component2);
 

--- a/ui/src/app/data-explorer/components/widgets/heatmap/heatmap-widget.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/heatmap/heatmap-widget.component.ts
@@ -102,7 +102,17 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
     
     let convXAxisData = [];
     xAxisData.forEach(x => {
-     const strDate = new Date(x).toLocaleString();
+     const date = new Date(x);
+     const size = 2;
+     const year = date.getFullYear();
+     const month = this.pad(date.getMonth()+1, size);
+     const day = date.getDate();
+     const hours = this.pad(date.getHours(), size);
+     const minutes = this.pad(date.getMinutes(), size);
+     const seconds = this.pad(date.getSeconds(), size);
+     const milli = this.pad(date.getMilliseconds(), 3);
+
+     const strDate = year + "-" + month + "-" + day + " " + hours + ":" + minutes + ":" + seconds + "." + milli;
      convXAxisData.push(strDate);
     });
 
@@ -148,14 +158,20 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
         const time = timeNames[timeIndex];
         const groupName = groupNames[groupNameIndex];
 
-        return '<style>' +
-               'ul {margin: 0px; padding: 0px; list-style-type: none; text-align: left}' +
-               '</style>' +
-               '<ul>' +
-               '<li><b>' + 'Time: ' + '</b>'+ time + '</li>' + 
-               '<li><b>' + 'Name: ' + '</b>' + groupName + '</li>' + 
-               '<li><b>' + 'Value: ' + '</b>' + value + '</li>' +
-               '</ul>';
+        let formattedTip = '<style>' +
+                          'ul {margin: 0px; padding: 0px; list-style-type: none; text-align: left}' +
+                          '</style>' +
+                          '<ul>' +
+                          '<li><b>' + 'Time: ' + '</b>'+ time + '</li>';
+
+        if (groupName !== '') {
+          formattedTip = formattedTip + '<li><b>' + 'Group: ' + '</b>' + groupName + '</li>';
+        }
+
+        formattedTip = formattedTip + '<li><b>' + 'Value: ' + '</b>' + value + '</li>' +
+                                      '</ul>';
+
+        return formattedTip;
        },
        position: 'top',
     }
@@ -235,5 +251,11 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
   transform(rows, index: number): any[] {
     return rows.map(row => row[index]);
   }
+
+  pad(num, size) {
+    num = num.toString();
+    while (num.length < size) num = "0" + num;
+    return num;
+}
 
 }

--- a/ui/src/app/data-explorer/components/widgets/heatmap/heatmap-widget.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/heatmap/heatmap-widget.component.ts
@@ -98,7 +98,15 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
     let max = -100000;
 
     const result = spQueryResult[0].allDataSeries;
-    const xAxisData = this.transform(result[0].rows, 0);
+    // const xAxisData = this.transform(result[0].rows, 0);
+
+    const aggregatedXData = [];
+    result.forEach(x => {
+      const localXAxisData = this.transform(x.rows, 0);
+      aggregatedXData.push(...localXAxisData)
+    });
+
+    const xAxisData = aggregatedXData.sort();
     
     let convXAxisData = [];
     xAxisData.forEach(x => {
@@ -141,8 +149,12 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
       max = localMax > max ? localMax : max;
       min = localMin < min ? localMin : min;
 
+      const localXAxisData = this.transform(groupedList.rows, 0);
+
       contentDataPure.map((cnt, colIndex) => {
-        contentData.push([colIndex, index, cnt]);
+        const currentX =  localXAxisData[colIndex];
+        const searchedIndex = aggregatedXData.indexOf(currentX)
+        contentData.push([searchedIndex, index, cnt]);
       });
     });
 

--- a/ui/src/app/data-explorer/components/widgets/heatmap/heatmap-widget.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/heatmap/heatmap-widget.component.ts
@@ -25,7 +25,7 @@ import { DataExplorerField } from '../../../models/dataview-dashboard.model';
 
 import { EChartsOption } from 'echarts';
 import { ECharts } from 'echarts/core';
-import { format } from 'echarts/core';
+import { time } from 'echarts/core';
 
 @Component({
   selector: 'sp-data-explorer-heatmap-widget',
@@ -99,6 +99,13 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
 
     const result = spQueryResult[0].allDataSeries;
     const xAxisData = this.transform(result[0].rows, 0);
+    
+    let convXAxisData = [];
+    xAxisData.forEach(x => {
+     const strDate = new Date(x).toLocaleString();
+     convXAxisData.push(strDate);
+    });
+
     const heatIndex = this.getColumnIndex(this.dataExplorerWidget.visualizationConfig.selectedHeatProperty, spQueryResult[0]);
 
     const yAxisData = [];
@@ -129,7 +136,7 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
       });
     });
 
-    const timeNames = xAxisData
+    const timeNames = convXAxisData
     const groupNames = yAxisData
 
     this.option['tooltip'] = {
@@ -161,7 +168,7 @@ export class HeatmapWidgetComponent extends BaseDataExplorerWidget<HeatmapWidget
 
     
 
-    return [contentData, xAxisData, yAxisData, min, max];
+    return [contentData, convXAxisData, yAxisData, min, max];
   }
 
   initOptions() {

--- a/ui/src/app/data-explorer/components/widgets/time-series-chart/time-series-chart-widget.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/time-series-chart/time-series-chart-widget.component.ts
@@ -387,15 +387,16 @@ export class TimeSeriesChartWidgetComponent extends BaseDataExplorerWidget<TimeS
         }
       });
 
-      for (const key in this.dataExplorerWidget.visualizationConfig.chosenColor) {
-        if (this.dataExplorerWidget.visualizationConfig.chosenColor.hasOwnProperty(key)) {
-          if (!collectNames.includes(key)) {
-            delete this.dataExplorerWidget.visualizationConfig.chosenColor[key];
-            delete this.dataExplorerWidget.visualizationConfig.displayName[key];
-            delete this.dataExplorerWidget.visualizationConfig.displayType[key];
-          }
-        }
-      }
+      // forget all configurations if deselected: 
+      // for (const key in this.dataExplorerWidget.visualizationConfig.chosenColor) {
+      //   if (this.dataExplorerWidget.visualizationConfig.chosenColor.hasOwnProperty(key)) {
+      //     if (!collectNames.includes(key)) {
+      //       delete this.dataExplorerWidget.visualizationConfig.chosenColor[key];
+      //       delete this.dataExplorerWidget.visualizationConfig.displayName[key];
+      //       delete this.dataExplorerWidget.visualizationConfig.displayType[key];
+      //     }
+      //   }
+      // }
 
     }
   }

--- a/ui/src/app/data-explorer/components/widgets/utils/select-color-properties/select-color-properties.component.html
+++ b/ui/src/app/data-explorer/components/widgets/utils/select-color-properties/select-color-properties.component.html
@@ -43,6 +43,19 @@
         <div fxFlex 
              fxLayoutAlign="end center" 
              *ngIf="isSelected(field)">
+             <mat-form-field
+                    class="marginColorFieldRight"
+                    color="accent"
+                    fxFlex="5">
+                <input matInput
+                        [(colorPicker)]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.fullDbName + field.sourceIndex.toString()]"
+                        [style.background]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.fullDbName + field.sourceIndex.toString()]"
+                        required
+                        [cpPosition]="'bottom'"
+                        [cpPresetColors]="presetColors"
+                        (colorPickerSelect)="triggerDataRefresh()"
+                        autocomplete="off"/>
+            </mat-form-field>
             <mat-form-field class="marginColorField"
                             color="accent"
                             fxFlex="60">
@@ -61,19 +74,6 @@
                     <mat-option [value]="'bar'">Bar</mat-option>
                     <mat-option [value]="'symbol_markers'">Symbol</mat-option>
                 </mat-select>
-            </mat-form-field>
-            <mat-form-field
-                    class="marginColorFieldRight"
-                    color="accent"
-                    fxFlex="5">
-                <input matInput
-                       [(colorPicker)]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.fullDbName + field.sourceIndex.toString()]"
-                       [style.background]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.fullDbName + field.sourceIndex.toString()]"
-                       required
-                       [cpPosition]="'bottom'"
-                       [cpPresetColors]="presetColors"
-                       (colorPickerSelect)="triggerDataRefresh()"
-                       autocomplete="off"/>
             </mat-form-field>
         </div>
     </div>


### PR DESCRIPTION
### Purpose
Data-explorer widgets such as heatmaps or time series charts display time-dependent information. Some widgets always calculate and display UCT instead of the respective local time. 

