### PR TITLE
The known vulnerability in the shared library zstd.Can you help upgrade to patch versions?

### DIFF
--- a/streampipes-wrapper-spark/pom.xml
+++ b/streampipes-wrapper-spark/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.3.8-1</version>
+                <version>1.4.9-1</version>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.paranamer</groupId>


### PR DESCRIPTION
Hi, @dominikriemer , @tenthe , I'd like to report a vulnerable dependency in **org.apache.streampipes:streampipes-wrapper-spark:0.69.0**.
### Issue Description
I noticed that **org.apache.streampipes:streampipes-wrapper-spark:0.69.0** directly depends on **com.github.luben:zstd-jni:v1.3.8-1**. However, as shown in the following dependency graph, **com.github.luben:zstd-jni:v1.3.8-1** sufferes from the vulnerability which the C library **zstd(version:1.3.8)** exposed: [CVE-2021-24031](https://nvd.nist.gov/vuln/detail/CVE-2021-24031).
### Dependency Graph between Java and Shared Libraries
![image (12)](https://user-images.githubusercontent.com/103260963/163182908-3929f004-84e0-4044-a9e4-1a03b5aef951.png)
### Suggested Vulnerability Patch Versions
**com.github.luben:zstd-jni:v1.4.9-1** (**>=v1.4.9-1**) has upgraded this vulnerable C library `zstd` to the patch version **1.4.9**.

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr