### PR TITLE
Potential security vulnerability in the lz4 C library. Can you help upgrade to patch versions?

### DIFF
--- a/streampipes-wrapper-spark/pom.xml
+++ b/streampipes-wrapper-spark/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.3.8-1</version>
+                <version>1.4.9-1</version>
             </dependency>
             <dependency>
                 <groupId>com.thoughtworks.paranamer</groupId>

--- a/streampipes-wrapper-spark/pom.xml
+++ b/streampipes-wrapper-spark/pom.xml
@@ -87,7 +87,7 @@
             <dependency>
                 <groupId>org.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
-                <version>1.5.0</version>
+                <version>1.7.0</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
Hi, @tejoha , @wipatrick , I'd like to report a vulnerable dependency in **org.apache.streampipes:streampipes-wrapper-spark:0.69.0**.
### Issue Description
I noticed that **org.apache.streampipes:streampipes-wrapper-spark:0.69.0** directly depends on **org.lz4:lz4-java:1.5.0**. However, as shown in the following dependency graph, **org.lz4:lz4-java:1.5.0** sufferes from the vulnerabilities which the C library **lz4(version:1.8.3)** exposed, containing 2 CVEs: [CVE-2021-3520](https://nvd.nist.gov/vuln/detail/CVE-2021-3520),[CVE-2019-17543](https://nvd.nist.gov/vuln/detail/CVE-2019-17543).
### Dependency Graph between Java and Shared Libraries
![image](https://user-images.githubusercontent.com/103260963/163203686-a8c26226-d436-4808-97d9-9490aa6e818c.png)

Furthermore, the vulnerable methods in the vulnerable shared libraries can be actually invoked by Java code. For instance, the following LZ4-JNI interfaces(Java code): `LZ4JNIFastDecompressor::decompress()`, `LZ4JNISafeDecompressor::decompress()`, `LZ4JNICompressor::compress()`  can reach the vulnerable method(C code)  `LZ4_write32()` reported by [CVE-2019-17543](https://nvd.nist.gov/vuln/detail/CVE-2019-17543). 
```
call chain----
LZ4JNISafeDecompressor::decompress() -> LZ4_decompress_safe() -> LZ4_decompress_generic() -> LZ4_write32()
LZ4JNIFastDecompressor::decompress() -> LZ4_decompress_fast() -> LZ4_decompress_generic() -> LZ4_write32()
LZ4JNICompressor::compress() -> LZ4_compress_limitedOutput() -> LZ4_compress_default -> LZ4_compress_fast -> LZ4_compress_fast_extState() -> LZ4_compress_generic() -> LZ4_write32()
```

### Suggested Vulnerability Patch Versions
**org.lz4:lz4-java:1.7.0** (**>=1.7.0**) has upgraded this vulnerable C library `lz4` to the patch version **1.9.2**. 

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr